### PR TITLE
[B-82785] Remove validation from dynamic query and report types

### DIFF
--- a/src/wizards/CodeGenerationWizard/Generation.cs
+++ b/src/wizards/CodeGenerationWizard/Generation.cs
@@ -288,48 +288,49 @@ namespace Sage.CA.SBS.ERP.Sage300.CodeGenerationWizard
         /// <returns>string.Empty if valid otherwise message to display</returns>
         private string ValidCodeTypeStep()
         {
-            // User ID
-            if (string.IsNullOrEmpty(txtUser.Text.Trim()))
-            {
-                return string.Format(Resources.InvalidSettingRequiredField, Resources.User.Replace(":", ""));
-            }
+            // Session - for code types that need to open a session to authenticate credentials
+            // If code type doesn't need to authenticate, this is automatically OK
+            var sessionValid = string.Empty;
 
-            // Password
-            //if (string.IsNullOrEmpty(txtPassword.Text.Trim()))
-            //{
-            //    return string.Format(Resources.InvalidSettingRequiredField, Resources.Password.Replace(":", ""));
-            //}
-
-            // Version
-            if (string.IsNullOrEmpty(txtVersion.Text.Trim()))
-            {
-                return string.Format(Resources.InvalidSettingRequiredField, Resources.Version.Replace(":", ""));
-            }
-
-            // Company
-            if (string.IsNullOrEmpty(txtCompany.Text.Trim()))
-            {
-                return string.Format(Resources.InvalidSettingRequiredField, Resources.Company.Replace(":", ""));
-            }
-
-            // Module
+            // Module - check for all code types
             if (string.IsNullOrEmpty(cboModule.Text.Trim()))
             {
                 return string.Format(Resources.InvalidSettingRequiredField, Resources.Module.Replace(":", ""));
             }
 
-            // Session
-            var sessionValid = string.Empty;
-            try
+            // Only perform additional validation on code types that require credentials
+            // Currently, this excludes Dynamic Query and Report types
+            if (grpCredentials.Enabled)
             {
-                // Init session to see if credentials are valid
-                var session = new Session();
-                session.InitEx2(null, string.Empty, "WX", "WX1000", txtVersion.Text.Trim(), 1);
-                session.Open(txtUser.Text.Trim(), txtPassword.Text.Trim(), txtCompany.Text.Trim(), DateTime.UtcNow, 0);
-            }
-            catch
-            {
-                sessionValid = Resources.InvalidSettingCredentials;
+                // User ID
+                if (string.IsNullOrEmpty(txtUser.Text.Trim()))
+                {
+                    return string.Format(Resources.InvalidSettingRequiredField, Resources.User.Replace(":", ""));
+                }
+
+                // Version
+                if (string.IsNullOrEmpty(txtVersion.Text.Trim()))
+                {
+                    return string.Format(Resources.InvalidSettingRequiredField, Resources.Version.Replace(":", ""));
+                }
+
+                // Company
+                if (string.IsNullOrEmpty(txtCompany.Text.Trim()))
+                {
+                    return string.Format(Resources.InvalidSettingRequiredField, Resources.Company.Replace(":", ""));
+                }
+
+                try
+                {
+                    // Init session to see if credentials are valid
+                    var session = new Session();
+                    session.InitEx2(null, string.Empty, "WX", "WX1000", txtVersion.Text.Trim(), 1);
+                    session.Open(txtUser.Text.Trim(), txtPassword.Text.Trim(), txtCompany.Text.Trim(), DateTime.UtcNow, 0);
+                }
+                catch
+                {
+                    sessionValid = Resources.InvalidSettingCredentials;
+                }
             }
 
             return sessionValid;


### PR DESCRIPTION
Minor refactor so the module check comes first as that is checked for all code types.
The flag for validation is based on whether the credentials group is enabled/disabled and not specifically dynamic query/report types.